### PR TITLE
Small fixes

### DIFF
--- a/src/main/java/org/nmrfx/structure/chemistry/io/NMRStarReader.java
+++ b/src/main/java/org/nmrfx/structure/chemistry/io/NMRStarReader.java
@@ -762,7 +762,7 @@ public class NMRStarReader {
         ResonanceFactory resFactory = PeakDim.resFactory;
         String listName = saveframe.getValue("_Spectral_peak_list", "Sf_framecode");
         String sampleLabel = saveframe.getLabelValue("_Spectral_peak_list", "Sample_label");
-        String sampleConditionLabel = saveframe.getOptionalValue("_Spectral_peak_list", "Sample_condition_list_label");
+        String sampleConditionLabel = saveframe.getOptionalLabelValue("_Spectral_peak_list", "Sample_condition_list_label");
         String datasetName = saveframe.getLabelValue("_Spectral_peak_list", "Experiment_name");
         String nDimString = saveframe.getValue("_Spectral_peak_list", "Number_of_spectral_dimensions");
         String dataFormat = saveframe.getOptionalValue("_Spectral_peak_list", "Text_data_format");

--- a/src/main/scripts/nmrfxs
+++ b/src/main/scripts/nmrfxs
@@ -24,6 +24,8 @@ else
     HEAP_MEM="512"
 fi
 
+JAVA=java
+
 # get the directory path of this script
 # resolve script symlink, if any
 pgm="$0"


### PR DESCRIPTION
1) Leading "$" was not being stripped from SampleConditionLabel when reading from STAR file. It was being set using SaveFrame.getOptionalValue method which has no logic to strip the leading "$". I have added a getOptionalLabelValue method rather than modifying getOptionalValue because I don't know whether it's safe to assume every leading "$" should be stripped.

2) $JAVA not always set in nmrfxs script 