### PR TITLE
Allow multiple projects to be loaded simultaneously

### DIFF
--- a/src/main/java/org/nmrfx/processor/datasets/peaks/AtomResonance.java
+++ b/src/main/java/org/nmrfx/processor/datasets/peaks/AtomResonance.java
@@ -82,7 +82,7 @@ public class AtomResonance extends SimpleResonance {
         List<String> nameColumn = loop.getColumnAsList("Name");
         List<String> resSetColumn = loop.getColumnAsList("Resonance_set_ID");
         // fixme unused ArrayList ssColumn = loop.getColumnAsList("Spin_system_ID");
-        AtomResonanceFactory resFactory = (AtomResonanceFactory) PeakDim.resFactory;
+        AtomResonanceFactory resFactory = (AtomResonanceFactory) PeakDim.resFactory();
         for (int i = 0, n = idColumn.size(); i < n; i++) {
             String value = null;
             long idNum = 0;
@@ -170,7 +170,7 @@ public class AtomResonance extends SimpleResonance {
                 //}
 
                 String mapID = entityAssemblyID + "." + entityID + "." + iRes;
-                Compound compound = (Compound) Molecule.compoundMap.get(mapID);
+                Compound compound = (Compound) Molecule.compoundMap().get(mapID);
                 if (compound == null) {
                     //throw new TclException("invalid compound in assignments saveframe \""+mapID+"\"");
                     System.err.println("invalid compound in assignments saveframe \"" + mapID + "\"");

--- a/src/main/java/org/nmrfx/project/StructureProject.java
+++ b/src/main/java/org/nmrfx/project/StructureProject.java
@@ -27,6 +27,9 @@ import org.nmrfx.processor.datasets.peaks.InvalidPeakException;
 import org.nmrfx.processor.star.ParseException;
 import org.nmrfx.structure.chemistry.InvalidMoleculeException;
 import org.nmrfx.structure.chemistry.Molecule;
+import org.nmrfx.structure.chemistry.constraints.AngleConstraintSet;
+import org.nmrfx.structure.chemistry.constraints.NoeSet;
+import org.nmrfx.structure.chemistry.constraints.RDCConstraintSet;
 import org.nmrfx.structure.chemistry.io.MoleculeIOException;
 import org.nmrfx.structure.chemistry.io.NMRStarReader;
 import org.nmrfx.structure.chemistry.io.NMRStarWriter;
@@ -42,9 +45,29 @@ import org.nmrfx.structure.chemistry.io.Sequence;
 public class StructureProject extends Project {
 
     public final Map<String, Molecule> molecules = new HashMap<>();
+    public Molecule activeMol;
+
+    public final Map compoundMap;
+
+    public final HashMap<String, NoeSet> NOE_SETS;
+    public NoeSet ACTIVE_SET;
+
+    public HashMap<String, AngleConstraintSet> angleSets;
+    public AngleConstraintSet activeSet;
+
+    public HashMap<String, RDCConstraintSet> rdcSets;
+    public RDCConstraintSet activeRDCSet;
 
     public StructureProject(String name) {
         super(name);
+        compoundMap = new HashMap();
+        activeMol = null;
+        NOE_SETS = new HashMap<String, NoeSet>();
+        ACTIVE_SET = null;
+        angleSets = new HashMap<String, AngleConstraintSet>();
+        activeSet = AngleConstraintSet.addSet("default");
+        rdcSets = new HashMap<String, RDCConstraintSet>();
+        activeRDCSet = null;
     }
 
     public static StructureProject getActive() {
@@ -80,6 +103,9 @@ public class StructureProject extends Project {
     }
 
     public void loadStructureProject(Path projectDir) throws IOException, MoleculeIOException, IllegalStateException {
+        Project currentProject=getActive();
+        setActive();
+
         loadProject(projectDir, "datasets");
         FileSystem fileSystem = FileSystems.getDefault();
 
@@ -121,6 +147,7 @@ public class StructureProject extends Project {
             }
         }
         this.projectDir = projectDir;
+        currentProject.setActive();
     }
 
     private File getSTAR3FileName() {
@@ -136,6 +163,8 @@ public class StructureProject extends Project {
     }
 
     public void saveProject() throws IOException {
+        Project currentProject=getActive();
+        setActive();
         try {
             if (projectDir == null) {
                 throw new IllegalArgumentException("Project directory not set");
@@ -147,6 +176,7 @@ public class StructureProject extends Project {
         } catch (ParseException | InvalidPeakException | InvalidMoleculeException ex) {
             throw new IOException(ex.getMessage());
         }
+        currentProject.setActive();
     }
 
     boolean loadSTAR3(Path directory) throws IOException {

--- a/src/main/java/org/nmrfx/structure/chemistry/Molecule.java
+++ b/src/main/java/org/nmrfx/structure/chemistry/Molecule.java
@@ -56,7 +56,9 @@ public class Molecule implements Serializable, ITree {
 
     public static List<Atom> atomList = null;
     public static final List<String> conditions = new ArrayList<>();
-    public static Molecule activeMol = null;
+    public static Molecule activeMol () {
+        return StructureProject.getActive().activeMol;
+    }
     public final Map<String, List<SpatialSet>> sites = new HashMap<>();
     public final List<SpatialSet> globalSelected = new ArrayList<>(1024);
     private final List<Bond> bselected = new ArrayList<>(1024);
@@ -91,7 +93,9 @@ public class Molecule implements Serializable, ITree {
     public static final LinkedHashSet colorTypes = new LinkedHashSet();
     public static final LinkedHashSet shapeTypes = new LinkedHashSet();
     //public static MoleculeTableModel molTableModel = null;
-    public static final Map compoundMap = new HashMap();
+    public static final Map compoundMap () {
+        return StructureProject.getActive().compoundMap;
+    }
     public Map<Atom, Map<Atom, Double>> ringClosures;
     List<List<Atom>> atomTree = null;
     HashMap<String, List> allowedSourcesMap = new HashMap<>();
@@ -240,7 +244,7 @@ public class Molecule implements Serializable, ITree {
         } catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
             atoms = new ArrayList<>();
         }
-        activeMol = this;
+        setActive();
         storeMolecule();
     }
 
@@ -285,11 +289,11 @@ public class Molecule implements Serializable, ITree {
     }
 
     public static Molecule getActive() {
-        return activeMol;
+        return StructureProject.getActive().activeMol;
     }
 
     public void setActive() {
-        activeMol = this;
+        StructureProject.getActive().activeMol = this;
     }
 
     public void reName(Molecule molecule, Compound compound, String name1, String name2) {
@@ -330,7 +334,7 @@ public class Molecule implements Serializable, ITree {
         StructureProject.getActive().clearAllMolecules();
 
         conditions.clear();
-        activeMol = null;
+        StructureProject.getActive().activeMol = null;
     }
 
     public void remove() {
@@ -348,9 +352,9 @@ public class Molecule implements Serializable, ITree {
 
         Collection<Molecule> mols = StructureProject.getActive().getMolecules();
 
-        activeMol = null;
+        StructureProject.getActive().activeMol = null;
         for (Molecule mol : mols) {
-            activeMol = mol;
+            StructureProject.getActive().activeMol = mol;
             break;
         }
     }
@@ -2244,7 +2248,7 @@ public class Molecule implements Serializable, ITree {
         List<Bond> selected = new ArrayList<>(32);
         Atom atomB;
         Atom atomE;
-        Molecule molecule = activeMol;
+        Molecule molecule = activeMol();
 
         if (molecule == null) {
             throw new IllegalArgumentException("No active molecule ");
@@ -4312,7 +4316,7 @@ public class Molecule implements Serializable, ITree {
     }
 
     public static void writeXYZ() {
-        Molecule molecule = activeMol;
+        Molecule molecule = activeMol();
 
         if (molecule == null) {
             return;
@@ -4333,7 +4337,7 @@ public class Molecule implements Serializable, ITree {
         int iStruct = 0;
         String result = null;
 
-        Molecule molecule = activeMol;
+        Molecule molecule = activeMol();
 
         if (molecule == null) {
             throw new InvalidMoleculeException("No active molecule");
@@ -4461,7 +4465,7 @@ public class Molecule implements Serializable, ITree {
     public static void writeXYZToPDB(Writer chan, int whichStruct) throws InvalidMoleculeException, IOException {
         int i;
 
-        Molecule molecule = activeMol;
+        Molecule molecule = activeMol();
 
         if (molecule == null) {
             throw new InvalidMoleculeException("No active molecule");

--- a/src/main/java/org/nmrfx/structure/chemistry/constraints/AngleConstraint.java
+++ b/src/main/java/org/nmrfx/structure/chemistry/constraints/AngleConstraint.java
@@ -18,6 +18,7 @@
 
 package org.nmrfx.structure.chemistry.constraints;
 
+import org.nmrfx.project.StructureProject;
 import org.nmrfx.structure.chemistry.SpatialSet;
 
 /**
@@ -26,7 +27,9 @@ import org.nmrfx.structure.chemistry.SpatialSet;
  */
 public class AngleConstraint implements Constraint {
 
-    private static AngleConstraintSet activeSet = AngleConstraintSet.addSet("default");
+    private static AngleConstraintSet activeSet () {
+        return StructureProject.getActive().activeSet;
+    }
     private static DistanceStat defaultStat = new DistanceStat();
 
     /**
@@ -49,8 +52,8 @@ public class AngleConstraint implements Constraint {
         this.lower = lower;
         this.upper = upper;
         this.name = name;
-        idNum = activeSet.getSize();
-        activeSet.setDirty();
+        idNum = activeSet().getSize();
+        activeSet().setDirty();
     }
 
     public SpatialSet getSpatialSet(int i) {
@@ -82,7 +85,7 @@ public class AngleConstraint implements Constraint {
     }
 
     public static void setActive(AngleConstraintSet noeSet) {
-        activeSet = noeSet;
+        StructureProject.getActive().activeSet = noeSet;
     }
 
     public void setActive(int state) {
@@ -94,15 +97,15 @@ public class AngleConstraint implements Constraint {
     }
 
     public static AngleConstraintSet getActiveSet() {
-        return activeSet;
+        return activeSet();
     }
 
     public static int getSize() {
-        return activeSet.getSize();
+        return activeSet().getSize();
     }
 
     public static void resetConstraints() {
-        activeSet.clear();
+        activeSet().clear();
     }
 
     public String getViolChars(DistanceStat dStat) {

--- a/src/main/java/org/nmrfx/structure/chemistry/constraints/AngleConstraintSet.java
+++ b/src/main/java/org/nmrfx/structure/chemistry/constraints/AngleConstraintSet.java
@@ -18,6 +18,7 @@
 
 package org.nmrfx.structure.chemistry.constraints;
 
+import org.nmrfx.project.StructureProject;
 import org.nmrfx.structure.chemistry.Atom;
 import org.nmrfx.structure.chemistry.Molecule;
 import org.nmrfx.structure.chemistry.Point3;
@@ -30,7 +31,9 @@ import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
  */
 public class AngleConstraintSet implements ConstraintSet, Iterable {
 
-    private static HashMap<String, AngleConstraintSet> angleSets = new HashMap<String, AngleConstraintSet>();
+    private static HashMap<String, AngleConstraintSet> angleSets () {
+        return StructureProject.getActive().angleSets;
+    }
     private ArrayList<AngleConstraint> constraints = new ArrayList<AngleConstraint>(64);
     int nStructures = 0;
     private final String name;
@@ -44,7 +47,7 @@ public class AngleConstraintSet implements ConstraintSet, Iterable {
 
     public static AngleConstraintSet addSet(String name) {
         AngleConstraintSet angleSet = new AngleConstraintSet(name);
-        angleSets.put(name, angleSet);
+        angleSets().put(name, angleSet);
         AngleConstraint.setActive(angleSet);
         return angleSet;
 
@@ -55,10 +58,10 @@ public class AngleConstraintSet implements ConstraintSet, Iterable {
     }
 
     public static void reset() {
-        for (Map.Entry<String, AngleConstraintSet> cSet : angleSets.entrySet()) {
+        for (Map.Entry<String, AngleConstraintSet> cSet : angleSets().entrySet()) {
             cSet.getValue().clear();
         }
-        angleSets.clear();
+        angleSets().clear();
         addSet("default");
     }
 
@@ -75,13 +78,13 @@ public class AngleConstraintSet implements ConstraintSet, Iterable {
     }
 
     public static AngleConstraintSet getSet(String name) {
-        AngleConstraintSet noeSet = angleSets.get(name);
+        AngleConstraintSet noeSet = angleSets().get(name);
         return noeSet;
     }
 
     public static ArrayList<String> getNames() {
         ArrayList<String> names = new ArrayList<String>();
-        for (String name : angleSets.keySet()) {
+        for (String name : angleSets().keySet()) {
             names.add(name);
         }
         return names;

--- a/src/main/java/org/nmrfx/structure/chemistry/constraints/NoeSet.java
+++ b/src/main/java/org/nmrfx/structure/chemistry/constraints/NoeSet.java
@@ -23,6 +23,7 @@ import java.util.*;
 import java.util.Map.Entry;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
+import org.nmrfx.project.StructureProject;
 import org.nmrfx.structure.chemistry.Atom;
 import org.nmrfx.structure.chemistry.Entity;
 import org.nmrfx.structure.chemistry.Molecule;
@@ -44,9 +45,13 @@ public class NoeSet implements ConstraintSet, Iterable {
     private static double CMAX_BONUS = 10.0;
     private static double MAX_BONUS = 20.0;
 
-    public static final HashMap<String, NoeSet> NOE_SETS = new HashMap<String, NoeSet>();
+    public static final HashMap<String, NoeSet> NOE_SETS () {
+        return StructureProject.getActive().NOE_SETS;
+    }
     private static boolean sumAverage = true;
-    static NoeSet ACTIVE_SET = null;
+    static NoeSet ACTIVE_SET () {
+        return StructureProject.getActive().ACTIVE_SET;
+    }
     private final List<Noe> constraints = new ArrayList<>(64);
     private final Map<Peak, List<Noe>> peakMap = new TreeMap<>();
     private final Map<PeakList, NoeCalibration> scaleMap = new HashMap<>();
@@ -65,24 +70,24 @@ public class NoeSet implements ConstraintSet, Iterable {
 
     public static NoeSet addSet(String name) {
         NoeSet noeSet = new NoeSet(name);
-        NOE_SETS.put(name, noeSet);
-        ACTIVE_SET = noeSet;
+        NOE_SETS().put(name, noeSet);
+        StructureProject.getActive().ACTIVE_SET = noeSet;
         return noeSet;
     }
 
     public static void reset() {
-        for (Map.Entry<String, NoeSet> cSet : NOE_SETS.entrySet()) {
+        for (Map.Entry<String, NoeSet> cSet : NOE_SETS().entrySet()) {
             cSet.getValue().clear();
         }
-        NOE_SETS.clear();
+        NOE_SETS().clear();
         addSet("default");
     }
 
     public static void remove(final String name) {
-        NoeSet noeSet = NOE_SETS.get(name);
+        NoeSet noeSet = NOE_SETS().get(name);
         if (noeSet != null) {
             noeSet.clear();
-            NOE_SETS.remove(name);
+            NOE_SETS().remove(name);
         }
     }
 
@@ -103,13 +108,13 @@ public class NoeSet implements ConstraintSet, Iterable {
     }
 
     public static NoeSet getSet(String name) {
-        NoeSet noeSet = NOE_SETS.get(name);
+        NoeSet noeSet = NOE_SETS().get(name);
         return noeSet;
     }
 
     public static List<String> getNames() {
         List<String> names = new ArrayList<String>();
-        for (String name : NOE_SETS.keySet()) {
+        for (String name : NOE_SETS().keySet()) {
             names.add(name);
         }
         return names;
@@ -117,7 +122,7 @@ public class NoeSet implements ConstraintSet, Iterable {
 
     public static List<NoeSet> getSets() {
         List<NoeSet> sets = new ArrayList<NoeSet>();
-        sets.addAll(NOE_SETS.values());
+        sets.addAll(NOE_SETS().values());
         return sets;
     }
 
@@ -145,7 +150,7 @@ public class NoeSet implements ConstraintSet, Iterable {
     }
 
     public static NoeSet getActiveSet() {
-        return ACTIVE_SET;
+        return ACTIVE_SET();
     }
 
     public Noe get(int i) {

--- a/src/main/java/org/nmrfx/structure/chemistry/constraints/RDCConstraintSet.java
+++ b/src/main/java/org/nmrfx/structure/chemistry/constraints/RDCConstraintSet.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.LineNumberReader;
+import org.nmrfx.project.StructureProject;
 import org.nmrfx.structure.chemistry.Molecule;
 import org.nmrfx.structure.chemistry.Point3;
 import java.util.*;
@@ -34,8 +35,12 @@ import org.nmrfx.structure.chemistry.Atom;
  */
 public class RDCConstraintSet implements ConstraintSet, Iterable {
 
-    private static HashMap<String, RDCConstraintSet> rdcSets = new HashMap<String, RDCConstraintSet>();
-    private static RDCConstraintSet activeSet = null;
+    private static HashMap<String, RDCConstraintSet> rdcSets () {
+        return StructureProject.getActive().rdcSets;
+    }
+    private static RDCConstraintSet activeSet () {
+        return StructureProject.getActive().activeRDCSet;
+    }
     private ArrayList<RDC> constraints = new ArrayList<>(64);
     int nStructures = 0;
     private final String name;
@@ -49,8 +54,8 @@ public class RDCConstraintSet implements ConstraintSet, Iterable {
 
     public static RDCConstraintSet addSet(String name) {
         RDCConstraintSet rdcSet = new RDCConstraintSet(name);
-        rdcSets.put(name, rdcSet);
-        activeSet = rdcSet;
+        rdcSets().put(name, rdcSet);
+        StructureProject.getActive().activeRDCSet = rdcSet;
         return rdcSet;
 
     }
@@ -60,10 +65,10 @@ public class RDCConstraintSet implements ConstraintSet, Iterable {
     }
 
     public static void reset() {
-        for (Map.Entry<String, RDCConstraintSet> cSet : rdcSets.entrySet()) {
+        for (Map.Entry<String, RDCConstraintSet> cSet : rdcSets().entrySet()) {
             cSet.getValue().clear();
         }
-        rdcSets.clear();
+        rdcSets().clear();
         addSet("default");
     }
 
@@ -80,13 +85,13 @@ public class RDCConstraintSet implements ConstraintSet, Iterable {
     }
 
     public static RDCConstraintSet getSet(String name) {
-        RDCConstraintSet noeSet = rdcSets.get(name);
+        RDCConstraintSet noeSet = rdcSets().get(name);
         return noeSet;
     }
 
     public static ArrayList<String> getNames() {
         ArrayList<String> names = new ArrayList<String>();
-        for (String name : rdcSets.keySet()) {
+        for (String name : rdcSets().keySet()) {
             names.add(name);
         }
         return names;

--- a/src/main/java/org/nmrfx/structure/chemistry/energy/AngleTreeGenerator.java
+++ b/src/main/java/org/nmrfx/structure/chemistry/energy/AngleTreeGenerator.java
@@ -256,7 +256,7 @@ public class AngleTreeGenerator {
         if (itree instanceof Molecule){
             mol = (Molecule) itree;
         } else {
-            mol = Molecule.activeMol;
+            mol = Molecule.activeMol();
         }
         ringFinder.findSmallestRings(mol);
         atomTree.forEach((branch) -> {

--- a/src/main/java/org/nmrfx/structure/chemistry/io/NMRStarReader.java
+++ b/src/main/java/org/nmrfx/structure/chemistry/io/NMRStarReader.java
@@ -366,7 +366,7 @@ public class NMRStarReader {
     }
 
     public void addCompound(String id, Compound compound) {
-        Molecule.compoundMap.put(id, compound);
+        Molecule.compoundMap().put(id, compound);
     }
 
     public void buildChemShifts(int fromSet, final int toSet) throws ParseException {
@@ -709,7 +709,7 @@ public class NMRStarReader {
                 entityAssemblyID = "1";
             }
             String mapID = entityAssemblyID + "." + iEntity + "." + iRes;
-            Compound compound1 = (Compound) Molecule.compoundMap.get(mapID);
+            Compound compound1 = (Compound) Molecule.compoundMap().get(mapID);
             if (compound1 != null) {
                 //throw new ParseException("invalid compound in assignments saveframe \""+mapID+"\"");
                 if ((atomName.charAt(0) == 'Q') || (atomName.charAt(0) == 'M')) {
@@ -741,7 +741,7 @@ public class NMRStarReader {
     }
 
     public void linkResonances() {
-        ResonanceFactory resFactory = PeakDim.resFactory;
+        ResonanceFactory resFactory = PeakDim.resFactory();
         for (Long resID : resMap.keySet()) {
             List<PeakDim> peakDims = resMap.get(resID);
             PeakDim firstPeakDim = peakDims.get(0);
@@ -759,7 +759,7 @@ public class NMRStarReader {
     }
 
     public void processSTAR3PeakList(Saveframe saveframe) throws ParseException {
-        ResonanceFactory resFactory = PeakDim.resFactory;
+        ResonanceFactory resFactory = PeakDim.resFactory();
         String listName = saveframe.getValue("_Spectral_peak_list", "Sf_framecode");
         String sampleLabel = saveframe.getLabelValue("_Spectral_peak_list", "Sample_label");
         String sampleConditionLabel = saveframe.getOptionalValue("_Spectral_peak_list", "Sample_condition_list_label");
@@ -1052,7 +1052,7 @@ public class NMRStarReader {
             List<String> valColumn = loop.getColumnAsList("Val");
             List<String> valErrColumn = loop.getColumnAsList("Val_err");
             List<String> resColumn = loop.getColumnAsList("Resonance_ID");
-            ResonanceFactory resFactory = PeakDim.resFactory;
+            ResonanceFactory resFactory = PeakDim.resFactory();
             for (int i = 0; i < entityAssemblyIDColumn.size(); i++) {
                 String iEntity = (String) entityIDColumn.get(i);
                 String entityAssemblyID = (String) entityAssemblyIDColumn.get(i);
@@ -1072,7 +1072,7 @@ public class NMRStarReader {
                     entityAssemblyID = "1";
                 }
                 String mapID = entityAssemblyID + "." + iEntity + "." + iRes;
-                Compound compound = (Compound) Molecule.compoundMap.get(mapID);
+                Compound compound = (Compound) Molecule.compoundMap().get(mapID);
                 if (compound == null) {
                     //throw new ParseException("invalid compound in assignments saveframe \""+mapID+"\"");
                     System.err.println("invalid compound in assignments saveframe \"" + mapID + "\"");
@@ -1164,7 +1164,7 @@ public class NMRStarReader {
                 entityAssemblyID = "1";
             }
             String mapID = entityAssemblyID + "." + iEntity + "." + iRes;
-            Compound compound = (Compound) Molecule.compoundMap.get(mapID);
+            Compound compound = (Compound) Molecule.compoundMap().get(mapID);
             if (compound == null) {
                 //throw new ParseException("invalid compound in conformer saveframe \""+mapID+"\"");
                 System.err.println("invalid compound in conformer saveframe \"" + mapID + "\"");
@@ -1376,7 +1376,7 @@ public class NMRStarReader {
                     entityAssemblyID = "1";
                 }
                 String mapID = entityAssemblyID + "." + iEntity + "." + iRes;
-                Compound compound1 = (Compound) Molecule.compoundMap.get(mapID);
+                Compound compound1 = (Compound) Molecule.compoundMap().get(mapID);
                 if (compound1 == null) {
                     //throw new ParseException("invalid compound in distance constraints saveframe \""+mapID+"\"");
                     System.err.println("invalid compound in distance constraints saveframe \"" + mapID + "\"");
@@ -1537,10 +1537,10 @@ public class NMRStarReader {
         if (DEBUG) {
             System.out.println("nSave " + star3.getSaveFrameNames());
         }
-        AtomResonanceFactory resFactory = (AtomResonanceFactory) PeakDim.resFactory;
+        AtomResonanceFactory resFactory = (AtomResonanceFactory) PeakDim.resFactory();
         if (argv.length == 0) {
             hasResonances = false;
-            Molecule.compoundMap.clear();
+            Molecule.compoundMap().clear();
             buildExperiments();
             if (DEBUG) {
                 System.err.println("process molecule");
@@ -1604,11 +1604,11 @@ public class NMRStarReader {
         if (DEBUG) {
             System.out.println("nSave " + star3.getSaveFrameNames());
         }
-        AtomResonanceFactory resFactory = (AtomResonanceFactory) PeakDim.resFactory;
+        AtomResonanceFactory resFactory = (AtomResonanceFactory) PeakDim.resFactory();
         Dihedral dihedral = null;
         if (argv.length == 0) {
             hasResonances = false;
-            Molecule.compoundMap.clear();
+            Molecule.compoundMap().clear();
 //            buildExperiments();
             if (DEBUG) {
                 System.err.println("process molecule");

--- a/src/main/java/org/nmrfx/structure/chemistry/io/NMRStarWriter.java
+++ b/src/main/java/org/nmrfx/structure/chemistry/io/NMRStarWriter.java
@@ -817,7 +817,7 @@ public class NMRStarWriter {
             peakWriter.writePeaksSTAR3(chan, peakList);
         }
 
-        AtomResonanceFactory resFactory = (AtomResonanceFactory) PeakDim.resFactory;
+        AtomResonanceFactory resFactory = (AtomResonanceFactory) PeakDim.resFactory();
 
         resFactory.writeResonancesSTAR3(chan);
         if (molecule != null) {


### PR DESCRIPTION
The pull request for nmrfxprocessor describes the aims and strategy. It is pasted below for reference.

In nmrfxstructure there are additional static variables which store project information that have been moved to instance variables within StructureProject:

    Molecule.activeMol
    Molecule.compoundMap
    NoeSet.NOE_SETS
    NoeSet.ACTIVE_SET
    AngleConstraintSet.angleSets
    AngleConstraint.activeSet
    RDCConstraintSet.rdcSets
    RDCConstraintSet.activeSet

These become:

    Molecule.activeMol -> theProject.activeMol
    Molecule.compoundMap -> theProject.compundMap
    NoeSet.NOE_SETS -> theProject.NOE_SETS
    NoeSet.ACTIVE_SET -> theProject.ACTIVE_SET
    AngleConstraintSet.angleSets -> theProject.angleSets
    AngleConstraint.activeSet -> theProject.activeSet
    RDCConstraintSet.rdcSets -> theProjecy.rdcSets
    RDCConstraintSet.activeSet -> theProject.activeRDCSet

Some of these names might be better if they were more descriptive, this was a probably unnecessary attempt to keep the changes as small as possible.

As before, the original static variables have been converted to static methods which return the relevant variable from the active project.

As before loadProject and saveProject methods updated to store the currently active project before making the owning object active, and then restore after the save or load is complete.

All references to original static variables have been updated to call the new methods instead.



---------- pull request message from nmrfxprocessor ----------

With our workflow, being able to easily access other projects (e.g. fragments of a larger molecule) would be highly enabling. The forthcoming pull requests are a suggestion for how this might be achieved. I appreciate you will probably be wary of this and so for this initial pull request the changes are minimal - if you agree with this approach then I can suggest some additional changes which facilitate this type of workflow.

The reason that it is not currently possible to load multiple projects is that there are a number of static variables which store project information which are set when a project is loaded and read from when a project is saved. In nmrfxprocessor these are:

Dataset.theFiles
PeakList.peakListTable
PeakDim.resFactory
PeakPath.peakPaths

I have changed these to be instances of a Project object, so they can be independently managed between projects.

Dataset.theFiles -> theProject.datasetList
PeakList.peakListTable -> theProject.peakListTable
PeakDim.resFactory -> theProject.resFactory
PeakPath.peakPaths -> theProject.peakPaths

The original static variables have been converted to static methods which return the relevant variable from the active project. For example:

private static HashMap<String, Dataset> theFiles = new HashMap<>();
Becomes:

private static HashMap<String, Dataset> theFiles () {
    return Project.getActive().datasetList;
}
And all references to Dataset.theFiles become Dataset.theFiles() .

The only other changes are in Project.java.

First, it is necessary that an active project is always return from Project.getActive(). If there is no activeProject, a new project is now created with the following precedence:

GUIStructureProject, StructureProject, GUIProject, Project

Finally, project.loadProject() and project.saveProject() store the currently active project before making the owning object active, and then restore after the save or load is complete.

In my testing, this allows me to load a project, and then (in Jython) do something like:

project1=Project("testproject1")
project1.loadProject(Paths.get("/Users/jan/soft/nmrfx/testproject1"))
project2=Project("testproject2")
project1.setActive()
project2.loadProject(Paths.get("/Users/jan/soft/nmrfx/testproject2"))

#access and modify peaklists, assignments etc. within each project

currentProject.saveProject()
subProject.saveProject()

