### PR TITLE
Fix inconsistent PeakList.listNum on project load

### DIFF
--- a/src/main/java/org/nmrfx/structure/chemistry/io/NMRStarReader.java
+++ b/src/main/java/org/nmrfx/structure/chemistry/io/NMRStarReader.java
@@ -776,6 +776,7 @@ public class NMRStarReader {
     public void processSTAR3PeakList(Saveframe saveframe) throws ParseException {
         ResonanceFactory resFactory = PeakDim.resFactory;
         String listName = saveframe.getValue("_Spectral_peak_list", "Sf_framecode");
+        String id = saveframe.getValue("_Spectral_peak_list", "ID");
         String sampleLabel = saveframe.getLabelValue("_Spectral_peak_list", "Sample_label");
         String sampleConditionLabel = saveframe.getOptionalLabelValue("_Spectral_peak_list", "Sample_condition_list_label");
         String datasetName = saveframe.getLabelValue("_Spectral_peak_list", "Experiment_name");
@@ -798,7 +799,7 @@ public class NMRStarReader {
         }
         int nDim = NvUtil.toInt(nDimString);
 
-        PeakList peakList = new PeakList(listName, nDim);
+        PeakList peakList = new PeakList(listName, nDim,NvUtil.toInt(id));
 
         int nSpectralDim = saveframe.loopCount("_Spectral_dim");
         if (nSpectralDim > nDim) {


### PR DESCRIPTION
Depends on corresponding commit in nmrfxprocessor:

https://github.com/onemoonsci/nmrfxprocessor/pull/14/commits/93d9e6b444f5cfc51835680b8b5c8cafadeed370

