### PR TITLE
Fix issues with clashing resonances

### DIFF
--- a/src/main/java/org/nmrfx/processor/datasets/peaks/AtomResonanceFactory.java
+++ b/src/main/java/org/nmrfx/processor/datasets/peaks/AtomResonanceFactory.java
@@ -47,7 +47,7 @@ public class AtomResonanceFactory extends ResonanceFactory implements FreezeList
     }
 
     public Resonance build() {
-        lastID++;
+        while (map.get(lastID++)!=null);
         AtomResonance resonance = new AtomResonance(lastID);
         map.put(lastID, resonance);
         return resonance;


### PR DESCRIPTION
On project load, current logic:

 - adds a new resonance to each peakDim
 - creates a map: resID -> List<PeakDims>
 - iterates through the map and _adds_ each of the
    peakDims in the entry to the resID key.

The side effect is that the peakDim originally
assigned to the resonance is still present in the
resonances peakDims list, causing undesired
behavior, especially noticeable when sliding
peaks. This bug may not manifest until the project
is somewhat mature as it is hidden when resonances
referred to in the STAR file are sequential.

After this commit the new logic is:

 - peaks are created without initializing
   resonances
 - resonances are added to peakDims with the
   correct ID.
 - any peakDim without a resonance has one created
   after all peaks have been processed.

To accommodate this it is necessary to modify
resonance.build() to ensure that an existing
resonance is not squashed, as they may be created
non-sequentially.